### PR TITLE
add category description

### DIFF
--- a/src/lib/pages/AddFeedbackPage.test.tsx
+++ b/src/lib/pages/AddFeedbackPage.test.tsx
@@ -55,6 +55,20 @@ describe('<AddFeedbackPage />', () => {
     })
   });
 
+  it("renders category description", async () => {
+    renderPage({
+      showAddFeedback: {
+        ...comment[0],
+        description: 'lorem ipsum'
+      }
+    })
+
+    await waitFor(() => {
+      const element = screen.getByTestId('add-feedback-category-description')
+      expect(element.textContent).toEqual('lorem ipsum')
+    })
+  });
+
   it('should not call add comments if no text is entered', async () => {
     renderPage()
 

--- a/src/lib/pages/AddFeedbackPage.tsx
+++ b/src/lib/pages/AddFeedbackPage.tsx
@@ -56,8 +56,9 @@ export const AddFeedbackPage = (
                 </div>
 
                 <div className="kt-flex kt-flex-col kt-items-center kt-space-y-4">
-                    <p className="kt-mt-2 kt-text-sm kt-text-gray-500 kt-text-center kt-w-5/6">
-                        to request a new feature in this application
+                    <p className="kt-mt-2 kt-text-sm kt-text-gray-500 kt-text-center kt-w-5/6"
+                        data-testid="add-feedback-category-description">
+                        {props.showAddFeedback.description || ''}
                     </p>
                     <textarea
                         className="kt-border-2 kt-rounded-md kt-w-full kt-h-24 kt-px-4"

--- a/src/lib/pages/ListCategoryPage.test.tsx
+++ b/src/lib/pages/ListCategoryPage.test.tsx
@@ -226,4 +226,35 @@ describe('<ListCategoryPage />', () => {
       expect(listCommentSpy).toHaveBeenCalledWith('proj-567891', 'category-2', 'user-1234', 'token')
     })
   })
+
+  it('should show category description if provided', async () => {
+    (getProject as jest.Mock).mockImplementation(() => {
+      return new Promise(resolve => {
+        resolve({
+          category: [
+            {
+              ...categoryData[0],
+              description: 'lorem ipsum'
+            },
+            ...categoryData
+          ],
+        })
+      })
+    });
+    (listComment as jest.Mock).mockImplementation(() => {
+      return new Promise(resolve => {
+        resolve(commentData)
+      })
+    });
+
+    renderPage({
+      projectId: 'proj-5678912'
+    })
+
+    await waitFor(() => {
+      const element = screen.getByTestId('list-category-item-description')
+      expect(element.textContent).toEqual('lorem ipsum')
+    })
+
+  })
 })

--- a/src/lib/pages/ListCategoryPage.tsx
+++ b/src/lib/pages/ListCategoryPage.tsx
@@ -141,8 +141,10 @@ export const ListCategoryPage = (
                     ))
                 }
             </div>
-            <p className="kt-mb-2 kt-text-sm kt-text-gray-500 kt-pl-2 kt-h-[20px]">
-                to request a new feature in this application
+            <p
+                className="kt-mb-2 kt-text-sm kt-text-gray-500 kt-pl-2 kt-pt-2 kt-text-center"
+                data-testid="list-category-item-description">
+                {selectedCategory?.description || ''}
             </p>
             <div className='kt-border-b-2 kt-border-slate-100'>
             </div>

--- a/src/style/generated.css
+++ b/src/style/generated.css
@@ -748,6 +748,10 @@ Ensure the default browser behavior of the `hidden` attribute.
   padding-left: 0.5rem;
 }
 
+.kt-pt-2 {
+  padding-top: 0.5rem;
+}
+
 .kt-text-left {
   text-align: left;
 }


### PR DESCRIPTION
**Link to Issue**

Fixes https://github.com/kaitakuhq/kaitaku-web-sdk/issues/31


**Testing**

<!-- If no tests are written, please provide a quick summary. -->

- [x] I've written unit and component tests
- [x] I've done an integration test using React example app and Vanilla JS.

**Screenshots (if applicable)**

| page | image |
|--|--|
| AddCategoryPage (w/o description) | <img width="430" alt="Screen Shot 2022-05-08 at 11 25 52" src="https://user-images.githubusercontent.com/6927131/167279150-d60d9652-c47c-441f-a5e5-f6d259ea0857.png"> |
| ListCategoryPage (w/o description) |  <img width="435" alt="Screen Shot 2022-05-08 at 11 25 49" src="https://user-images.githubusercontent.com/6927131/167279151-52670d7b-2d61-4838-b8bd-709c4119a466.png"> |
| AddCategoryPage (w description) | <img width="426" alt="Screen Shot 2022-05-08 at 11 27 05" src="https://user-images.githubusercontent.com/6927131/167279158-29c13f3f-8b59-4fd3-95b9-a553b491a9ce.png"> |
| ListCategoryPage (w description) |  <img width="427" alt="Screen Shot 2022-05-08 at 11 27 01" src="https://user-images.githubusercontent.com/6927131/167279160-3faa3911-5e01-4e16-bc38-68b4352e6c75.png"> |


**Documentation**

- [ ] This requires a documentaion and I've updated it.

